### PR TITLE
Updated Readme to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ Follows the [Cordova Plugin spec](https://github.com/apache/cordova-plugman/blob
 This plugin leverages Cordova/PhoneGap's [require/define functionality used for plugins](http://simonmacdonald.blogspot.ca/2012/08/so-you-wanna-write-phonegap-200-android.html). 
 
 ## Using the plugin ##
-The plugin creates the object `window.BackgroundFetch` with the methods `configure(success, fail, option)`, `start(success, fail)` and `stop(success, fail). 
+The plugin creates the object `window.BackgroundFetch` with the following methods:
+
+* `configure(callback, failure, config)`
+* `finish(success, failure)`
+
+Additionally, the following properties are available:
+
+* `config` - the value supplied as the third argument to the `configure` method above
+* `isActive` - The current state of the plugin. Will be set to `true` after `configure` is successfully called and `false` after `finish`.
+
+**Note** for those upgrading from a previous version, the `start(success, fail)` and `stop(success, fail)` functions have been removed
 
 ## Installing the plugin ##
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ This plugin leverages Cordova/PhoneGap's [require/define functionality used for 
 ## Using the plugin ##
 The plugin creates the object `window.BackgroundFetch` with the following methods:
 
-* `configure(callback, failure, config)`
-* `finish(success, failure)`
+* `configure(callback, failure, config)` : Used to Initialize the BackgroundFetch plugin. 
+* `finish(success, failure)` : Used to indicate that you have finished executing your code. Must be called to signal to the OS that you are done
 
 Additionally, the following properties are available:
 
-* `config` - the value supplied as the third argument to the `configure` method above
-* `isActive` - The current state of the plugin. Will be set to `true` after `configure` is successfully called and `false` after `finish`.
+* `config` - will be value supplied as the third argument to the `configure` method above
+* `isActive` - Represents whether there is a currently active backgroundFetch operation running.
 
 **Note** for those upgrading from a previous version, the `start(success, fail)` and `stop(success, fail)` functions have been removed
 


### PR DESCRIPTION
Since the `start` and `stop` methods were removed in [8c757c0](https://github.com/christocracy/cordova-plugin-background-fetch/commit/8c757c0ef9ea83658b765f0b831aa6608d5cc3f2#diff-72cfc5a86169a45964062d8ed54e078a), I've updated the README file to remove references from those two methods - and prevent confusion and errors.

I've also added a brief explanation of the two methods available on the object: `configure` and `finish`. Updated to give an explanation consistent with how the plugin should be used since I had previously misunderstood the purpose of the `finish` method.

Just trying to help others avoid the confusion that I experienced when finding the plugin to function differently from what the README indicated.