### PR TITLE
README: `adb shell cmd` only for api 24+

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ export class HomePage {
 ```bash
 $ adb logcat -s TSBackgroundFetch
 ```
-- Simulate a background-fetch event on a device (insert *&lt;your.application.id&gt;*) (only works for sdk `21+`:
+- Simulate a background-fetch event on a device (insert *&lt;your.application.id&gt;*) (only works for sdk `24+`):
 ```bash
 $ adb shell cmd jobscheduler run -f <your.application.id> 999
 ```


### PR DESCRIPTION
The current README says that `adb shell cmd jobscheduler run` can be used for api 21+, however this command was added in https://android.googlesource.com/platform/frameworks/base/+/5d34605, which is only present in Android 7.0 (api >=24)

Source: https://developer.android.com/topic/performance/background-optimization.html#further-optimization