### PR TITLE
Define a custom node_modules directory

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,12 +1,13 @@
 def NAME = "cordova-plugin-background-fetch"
 
 def libDir = "${projectDir}/libs"
+def nodeModulesDir = (project.hasProperty("nodeModulesDirectory")) ? project.property("nodeModulesDirectory") : "../../node_modules"
 
 File capacitorConfig = new File("${projectDir}/../../capacitor.config.json")
 
 if (capacitorConfig.exists()) {
   // Capacitor app
-  libDir = "${projectDir}/../../node_modules/${NAME}/src/android/libs"
+  libDir = "${projectDir}/${nodeModulesDir}/${NAME}/src/android/libs"
   println("[${NAME}] Capacitor detected")
 }
 


### PR DESCRIPTION
This is a sister PR to https://github.com/transistorsoft/cordova-background-geolocation/pull/2128

A normal Angular/Ionic repo has `android` and `node_modules` folders on the same level, like this.

* project
  * node_modules
  * android

For project-specific reasons, our repo looks like this:

* project
  * ionic_project
    * android
  * other_project
  * shared_project
  * node_modules

Therefore, we need the `libDir` to point to `${projectDir}/../../../node_modules`, not `${projectDir}/../../node_modules`.

I believe this commit solves the issue. By default, `libDir` will point to `${projectDir}/../../node_modules`. If you put a `nodeModulesDirectory` in your app's variables.gradle, then you can override the default and set the relative node_modules directory needed for your project.

Perhaps the gradle variable needs an app specific prefix? I haven't done much Gradle/Android dev, so perhaps there is a better way to place this variable.